### PR TITLE
correction for Timezone and opening

### DIFF
--- a/R/get_game_data.R
+++ b/R/get_game_data.R
@@ -72,7 +72,7 @@ get_each_player <- function(username) {
     cleaned_df <- cleaned_df %>% dplyr::filter(!stringr::str_detect(.data$pgn, "club/matches"))
 
     cleaned_df <- cleaned_df %>%
-      tidyr::separate(.data$pgn, into = c("Event", "Site", "Date", "Round", "White", "Black", "Result", "ECO", "ECOUrl", "CurrentPosition", "Timezone",
+      tidyr::separate(.data$pgn, into = c("Event", "Site", "Date", "Round", "White", "Black", "Result", "CurrentPosition", "Timezone", "ECO", "ECOUrl",
                                     "UTCDate", "UTCTime", "WhiteElo", "BlackElo", "TimeControl", "Termination", "StartTime", "EndDate", "EndTime",
                                     "Link", "Moves"), sep = "]\n")
 


### PR DESCRIPTION
Great work! For some reason, I see Timezone and openings (ECO) around the other way from the API. This PR corrects that, but please confirm that it's reproducible, first - your docs show the correct result.