### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 inst/doc
 .DS_Store
+chessR.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: chessR
 Type: Package
 Title: Functions to Extract, Clean and Analyse Online Chess Game Data
-Version: 1.5.0.1000
+Version: 1.5.0.2000
 Authors@R: c(person("Jason Zivkovic", email = "jase.ziv83@gmail.com",
                   role = c("aut", "cre")),
              person("Jonathan", "Carroll", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# chessR 1.5.0.2000
+
+Bugfix: `plot_moves()` now correctly shows _all_ moves (@jonocarroll)
+Feature: `plot_moves()` now takes a `sleep` argument which can be used to alter the speed of plot increments, 
+  e.g. slower/faster for interactive use, or `sleep = 0` for producing a gif (@jonocarroll)
+Feature: `extract_moves()` and `extract_moves_as_game()` can now take a local PGN file as input (@jonocarroll)
+Feature: explored variations are now stripped from move input (@jonocarroll)
+
+***
+
 # chessR 1.5.0.1000
 
 New function `lichess_clock_move_time` created to extract clock and move times from Lichess game data

--- a/R/moves.R
+++ b/R/moves.R
@@ -6,7 +6,11 @@
 #' @export
 extract_moves <- function(moves_string) {
   stopifnot("only a single moves_string can be provided" = length(moves_string) == 1L)
+  # remove newlines
   clean <- stringr::str_remove_all(moves_string, "\\\n")
+  # remove explored lines
+  clean <- stringr::str_remove_all(moves_string, "\\(.*?\\)")
+  # remove annotations
   noclock <- stringr::str_remove_all(clean, "\\{.*?\\}")
   remove_ending <- stringr::str_remove(noclock, "[0-9]-[0-9]")
   parsed <- tidyr::separate_rows(data.frame(move = remove_ending), .data$move, sep = "[0-9]+\\.")

--- a/R/moves.R
+++ b/R/moves.R
@@ -78,7 +78,8 @@ plot_moves <- function(game, interactive = TRUE) {
   }
   step <- chess::root(game)
   plot(step)
-  for (i in seq_len(chess::move_number(game))) {
+  for (i in seq_len(2*chess::move_number(game))) {
+    if (chess::is_checkmate(step)) break
     step <- chess::forward(step)
     plot(step)
     if (interactive) {

--- a/R/moves.R
+++ b/R/moves.R
@@ -62,6 +62,7 @@ extract_moves_as_game <- function(game) {
 #'
 #' @param game a [chess::game()] object, likely with moves identified
 #' @param interactive wait for 'Enter' after each move? Turn off to use in a gif
+#' @param sleep how long to wait between moves
 #'
 #' @return `NULL`, (invisibly) - called for the side-effect of plotting
 #' @export
@@ -72,7 +73,7 @@ extract_moves_as_game <- function(game) {
 #' m <- extract_moves_as_game(hikaru[11, ])
 #' plot_moves(m)
 #' }
-plot_moves <- function(game, interactive = TRUE) {
+plot_moves <- function(game, interactive = TRUE, sleep = 1) {
   if (!requireNamespace("chess", quietly = TRUE)) {
     stop("This function requires the {chess} package to be installed.")
   }
@@ -85,7 +86,7 @@ plot_moves <- function(game, interactive = TRUE) {
     if (interactive) {
       readline("Press enter to continue...")
     } else {
-      Sys.sleep(1)
+      Sys.sleep(sleep)
     }
   }
   return(invisible(NULL))

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,16 +14,12 @@ knitr::opts_chunk$set(
 options(tibble.print_min = 5, tibble.print_max = 5)
 ```
 
-# chessR <a href='https://jaseziv.github.io/chessR/'><img src='man/figures/logo.png' align="right" height="219.5" /></a>
+# chessR <a href='https:/jaseziv.github.io/chessR'><img src='man/figures/logo.png' align="right" height="219.5" /></a>
 
 <!-- badges: start -->
 [![Version-Number](https://img.shields.io/github/r-package/v/JaseZiv/chessR?label=chessR (Dev))](https://github.com/JaseZiv/chessR/)
 [![R build status](https://github.com/JaseZiv/chessR/workflows/R-CMD-check/badge.svg)](https://github.com/JaseZiv/chessR/actions)
-[![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://app.codecov.io/gh/JaseZiv/chessR)
-
-[![CRAN status](https://www.r-pkg.org/badges/version-last-release/chessR?style=for-the-badge)](https://CRAN.R-project.org/package=chessR)
-[![CRAN downloads](http://cranlogs.r-pkg.org/badges/grand-total/chessR)](https://CRAN.R-project.org/package=chessR)
-[![Downloads](https://cranlogs.r-pkg.org/badges/chessR)](https://cran.r-project.org/package=chessR)
+[![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://codecov.io/gh/JaseZiv/chessR)
 <!-- badges: end -->
 
 ## Overview
@@ -38,25 +34,12 @@ These websites offer a very convenient set of APIs to be able to access data and
 
 ## Installation
 
-You can install the CRAN version of [**```chessR```** ](https://CRAN.R-project.org/package=chessR) with:
+You can install the `chessR` package from github with:
 
-```{r cran-installation, eval=FALSE}
-install.packages("chessR")
-```
-
-You can install the released version of [**```chessR```**](https://github.com/JaseZiv/chessR/) from [GitHub](https://github.com/JaseZiv/worldfootballR) with:
-
-```{r gh-installation, eval=FALSE}
+```{r gh-installation, eval = FALSE}
 # install.packages("devtools")
 devtools::install_github("JaseZiv/chessR")
 ```
-
-
-```{r load_libs, warning=FALSE, message=FALSE}
-library(chessR)
-```
-
-***
 
 
 ## Usage
@@ -100,7 +83,7 @@ This is only available for chess.com extracts
 ```{r get_analysis, eval=FALSE}
 chess_analysis_single <- get_game_data("JaseZiv")
 
-chess_analysis_multiple <- get_game_data(c("JaseZiv", "Smudgy1"))
+chess_analysis_multiple <- get_game_data(c("JaseZiv", "elroch"))
 
 ```
 
@@ -140,8 +123,9 @@ hikaru <- chessR:::get_each_player_chessdotcom("hikaru", "202112")
 # convert to {chess} 'game' format
 m <- extract_moves_as_game(hikaru[11, ])
 # plot each move and save all as a gif
+# set sleep to 0 to avoid needing to plot in realtime
 gifski::save_gif({
-  plot_moves(m, interactive = FALSE)
+  plot_moves(m, interactive = FALSE, sleep = 0)
 }, 
 gif_file = "~/Hikaru_Naroditsky.gif", 
 delay = 1)

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,12 +14,16 @@ knitr::opts_chunk$set(
 options(tibble.print_min = 5, tibble.print_max = 5)
 ```
 
-# chessR <a href='https:/jaseziv.github.io/chessR'><img src='man/figures/logo.png' align="right" height="219.5" /></a>
+# chessR <a href='https://jaseziv.github.io/chessR/'><img src='man/figures/logo.png' align="right" height="219.5" /></a>
 
 <!-- badges: start -->
 [![Version-Number](https://img.shields.io/github/r-package/v/JaseZiv/chessR?label=chessR (Dev))](https://github.com/JaseZiv/chessR/)
 [![R build status](https://github.com/JaseZiv/chessR/workflows/R-CMD-check/badge.svg)](https://github.com/JaseZiv/chessR/actions)
-[![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://codecov.io/gh/JaseZiv/chessR)
+[![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://app.codecov.io/gh/JaseZiv/chessR)
+
+[![CRAN status](https://www.r-pkg.org/badges/version-last-release/chessR?style=for-the-badge)](https://CRAN.R-project.org/package=chessR)
+[![CRAN downloads](http://cranlogs.r-pkg.org/badges/grand-total/chessR)](https://CRAN.R-project.org/package=chessR)
+[![Downloads](https://cranlogs.r-pkg.org/badges/chessR)](https://cran.r-project.org/package=chessR)
 <!-- badges: end -->
 
 ## Overview
@@ -34,12 +38,25 @@ These websites offer a very convenient set of APIs to be able to access data and
 
 ## Installation
 
-You can install the `chessR` package from github with:
+You can install the CRAN version of [**```chessR```** ](https://CRAN.R-project.org/package=chessR) with:
 
-```{r gh-installation, eval = FALSE}
+```{r cran-installation, eval=FALSE}
+install.packages("chessR")
+```
+
+You can install the released version of [**```chessR```**](https://github.com/JaseZiv/chessR/) from [GitHub](https://github.com/JaseZiv/worldfootballR) with:
+
+```{r gh-installation, eval=FALSE}
 # install.packages("devtools")
 devtools::install_github("JaseZiv/chessR")
 ```
+
+
+```{r load_libs, warning=FALSE, message=FALSE}
+library(chessR)
+```
+
+***
 
 
 ## Usage
@@ -83,7 +100,7 @@ This is only available for chess.com extracts
 ```{r get_analysis, eval=FALSE}
 chess_analysis_single <- get_game_data("JaseZiv")
 
-chess_analysis_multiple <- get_game_data(c("JaseZiv", "elroch"))
+chess_analysis_multiple <- get_game_data(c("JaseZiv", "Smudgy1"))
 
 ```
 
@@ -123,7 +140,7 @@ hikaru <- chessR:::get_each_player_chessdotcom("hikaru", "202112")
 # convert to {chess} 'game' format
 m <- extract_moves_as_game(hikaru[11, ])
 # plot each move and save all as a gif
-# set sleep to 0 to avoid needing to plot in realtime
+# set sleep = 0 so the rendering doesn't happen in realtime
 gifski::save_gif({
   plot_moves(m, interactive = FALSE, sleep = 0)
 }, 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# chessR <a href='https://jaseziv.github.io/chessR/'><img src='man/figures/logo.png' align="right" height="219.5" /></a>
+# chessR <a href='https:/jaseziv.github.io/chessR'><img src='man/figures/logo.png' align="right" height="219.5" /></a>
 
 <!-- badges: start -->
 
 [![Version-Number](https://img.shields.io/github/r-package/v/JaseZiv/chessR?label=chessR%20(Dev))](https://github.com/JaseZiv/chessR/)
 [![R build
 status](https://github.com/JaseZiv/chessR/workflows/R-CMD-check/badge.svg)](https://github.com/JaseZiv/chessR/actions)
-[![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://app.codecov.io/gh/JaseZiv/chessR)
-
-[![CRAN
-status](https://www.r-pkg.org/badges/version-last-release/chessR?style=for-the-badge)](https://CRAN.R-project.org/package=chessR)
-[![CRAN
-downloads](http://cranlogs.r-pkg.org/badges/grand-total/chessR)](https://CRAN.R-project.org/package=chessR)
-[![Downloads](https://cranlogs.r-pkg.org/badges/chessR)](https://cran.r-project.org/package=chessR)
+[![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://codecov.io/gh/JaseZiv/chessR)
 <!-- badges: end -->
 
 ## Overview
@@ -33,27 +27,12 @@ for Lichess](https://lichess.org/api).
 
 ## Installation
 
-You can install the CRAN version of
-[**`chessR`**](https://CRAN.R-project.org/package=chessR) with:
-
-``` r
-install.packages("chessR")
-```
-
-You can install the released version of
-[**`chessR`**](https://github.com/JaseZiv/chessR/) from
-[GitHub](https://github.com/JaseZiv/worldfootballR) with:
+You can install the `chessR` package from github with:
 
 ``` r
 # install.packages("devtools")
 devtools::install_github("JaseZiv/chessR")
 ```
-
-``` r
-library(chessR)
-```
-
-------------------------------------------------------------------------
 
 ## Usage
 
@@ -101,7 +80,7 @@ vector of multiple players.
 ``` r
 chess_analysis_single <- get_game_data("JaseZiv")
 
-chess_analysis_multiple <- get_game_data(c("JaseZiv", "Smudgy1"))
+chess_analysis_multiple <- get_game_data(c("JaseZiv", "elroch"))
 ```
 
 ### Leaderboards
@@ -152,8 +131,9 @@ hikaru <- chessR:::get_each_player_chessdotcom("hikaru", "202112")
 # convert to {chess} 'game' format
 m <- extract_moves_as_game(hikaru[11, ])
 # plot each move and save all as a gif
+# set sleep to 0 to avoid needing to plot in realtime
 gifski::save_gif({
-  plot_moves(m, interactive = FALSE)
+  plot_moves(m, interactive = FALSE, sleep = 0)
 }, 
 gif_file = "~/Hikaru_Naroditsky.gif", 
 delay = 1)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# chessR <a href='https:/jaseziv.github.io/chessR'><img src='man/figures/logo.png' align="right" height="219.5" /></a>
+# chessR <a href='https://jaseziv.github.io/chessR/'><img src='man/figures/logo.png' align="right" height="219.5" /></a>
 
 <!-- badges: start -->
 
 [![Version-Number](https://img.shields.io/github/r-package/v/JaseZiv/chessR?label=chessR%20(Dev))](https://github.com/JaseZiv/chessR/)
 [![R build
 status](https://github.com/JaseZiv/chessR/workflows/R-CMD-check/badge.svg)](https://github.com/JaseZiv/chessR/actions)
-[![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://codecov.io/gh/JaseZiv/chessR)
+[![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://app.codecov.io/gh/JaseZiv/chessR)
+
+[![CRAN
+status](https://www.r-pkg.org/badges/version-last-release/chessR?style=for-the-badge)](https://CRAN.R-project.org/package=chessR)
+[![CRAN
+downloads](http://cranlogs.r-pkg.org/badges/grand-total/chessR)](https://CRAN.R-project.org/package=chessR)
+[![Downloads](https://cranlogs.r-pkg.org/badges/chessR)](https://cran.r-project.org/package=chessR)
 <!-- badges: end -->
 
 ## Overview
@@ -27,12 +33,27 @@ for Lichess](https://lichess.org/api).
 
 ## Installation
 
-You can install the `chessR` package from github with:
+You can install the CRAN version of
+[**`chessR`**](https://CRAN.R-project.org/package=chessR) with:
+
+``` r
+install.packages("chessR")
+```
+
+You can install the released version of
+[**`chessR`**](https://github.com/JaseZiv/chessR/) from
+[GitHub](https://github.com/JaseZiv/worldfootballR) with:
 
 ``` r
 # install.packages("devtools")
 devtools::install_github("JaseZiv/chessR")
 ```
+
+``` r
+library(chessR)
+```
+
+------------------------------------------------------------------------
 
 ## Usage
 
@@ -80,7 +101,7 @@ vector of multiple players.
 ``` r
 chess_analysis_single <- get_game_data("JaseZiv")
 
-chess_analysis_multiple <- get_game_data(c("JaseZiv", "elroch"))
+chess_analysis_multiple <- get_game_data(c("JaseZiv", "Smudgy1"))
 ```
 
 ### Leaderboards
@@ -131,7 +152,7 @@ hikaru <- chessR:::get_each_player_chessdotcom("hikaru", "202112")
 # convert to {chess} 'game' format
 m <- extract_moves_as_game(hikaru[11, ])
 # plot each move and save all as a gif
-# set sleep to 0 to avoid needing to plot in realtime
+# set sleep = 0 so the rendering doesn't happen in realtime
 gifski::save_gif({
   plot_moves(m, interactive = FALSE, sleep = 0)
 }, 

--- a/man/chessR.Rd
+++ b/man/chessR.Rd
@@ -22,6 +22,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item Jonathan Carroll \email{rpkg@jcarroll.com.au} (\href{https://orcid.org/0000-0002-1404-5264}{ORCID}) [contributor]
+  \item Dan Wakeling \email{danwakeling7@gmail.com} [contributor]
 }
 
 }

--- a/man/extract_moves.Rd
+++ b/man/extract_moves.Rd
@@ -7,7 +7,8 @@
 extract_moves(moves_string)
 }
 \arguments{
-\item{moves_string}{string containing moves built by `chessR` (e.g. from \url{https://www.chess.com/})}
+\item{moves_string}{string containing moves built by `chessR` (e.g. from \url{https://www.chess.com/})
+or the filename of a PGN file}
 }
 \value{
 cleaned moves as a data.frame

--- a/man/extract_moves_as_game.Rd
+++ b/man/extract_moves_as_game.Rd
@@ -7,7 +7,8 @@
 extract_moves_as_game(game)
 }
 \arguments{
-\item{game}{a single row of a `data.frame` provided by `chessR` containing move information}
+\item{game}{a single row of a `data.frame` provided by `chessR` containing move information
+or the filename of a PGN file}
 }
 \value{
 a [chess::game()] game object

--- a/man/plot_moves.Rd
+++ b/man/plot_moves.Rd
@@ -4,7 +4,7 @@
 \alias{plot_moves}
 \title{Plot a game}
 \usage{
-plot_moves(game, interactive = TRUE)
+plot_moves(game, interactive = TRUE, sleep = 1)
 }
 \arguments{
 \item{game}{a [chess::game()] object, likely with moves identified}

--- a/man/plot_moves.Rd
+++ b/man/plot_moves.Rd
@@ -10,6 +10,8 @@ plot_moves(game, interactive = TRUE, sleep = 1)
 \item{game}{a [chess::game()] object, likely with moves identified}
 
 \item{interactive}{wait for 'Enter' after each move? Turn off to use in a gif}
+
+\item{sleep}{how long to wait between moves}
 }
 \value{
 `NULL`, (invisibly) - called for the side-effect of plotting


### PR DESCRIPTION
These improvements are split out by commit, but in summary:

* [read local PGN](https://github.com/JaseZiv/chessR/commit/0491871fbc4e4d1888ca49378daeb60f7c297854) - adds the ability to read a local PGN file. Now `extract_moves()` and `extract_moves_as_game()` can take a filepath. It might make sense to either update the argument name or use a different argument.
* [strip explored variations from moves](https://github.com/JaseZiv/chessR/commit/71d5d0e1d9fa069467f1d53cfc0fb63238ecc733) - I noticed that a PGN I wanted to load had some explored sidelines and these were messing with the move extraction
* [plot all the moves](https://github.com/JaseZiv/chessR/commit/3fb486867eb1ad7233f2c00076514bcada29e64b) - `chess::move_number()` seems to count both players as a single "move" so this was undercounting the maximum number of moves by half. To deal with white delivering checkmate this exits the loop early in that case
* [add sleep parameter to plot_moves](https://github.com/JaseZiv/chessR/commit/d3c10623198252e1824933dcd73694927e980204) - when creating gif of the moves you shouldn't have to wait for it to plot in realtime, so a `sleep` parameter can now be set to 0. Also useful if you just want to watch it run faster.



0 errors ✓ | 0 warnings ✓ | 0 notes ✓