### PR TITLE
add since and until (lichess)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: chessR
 Type: Package
 Title: Functions to Extract, Clean and Analyse Online Chess Game Data
-Version: 1.5.2
+Version: 1.5.3
 Authors@R: c(person("Jason Zivkovic", email = "jase.ziv83@gmail.com",
                   role = c("aut", "cre")),
              person("Jonathan", "Carroll", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# chessR 1.5.3
+
+Feature: `get_raw_lichess()` can now be filtered by date with the parameters
+`since` and `until` (@py-b #16)
+
+***
+
 # chessR 1.5.2
 
 CRAN suggestions for functions to fail gracefully.

--- a/R/get_raw_lichess.R
+++ b/R/get_raw_lichess.R
@@ -30,14 +30,14 @@ get_raw_lichess <- function(player_names, since = NULL, until = NULL) {
 
     since_query <- ""
     if (!is.null(since)) {
-      # API parameters since awaits number of milliseconds since 1970-01-01
+      # API parameter since awaits number of milliseconds since 1970-01-01
       since_integer <- as.integer(as.Date(since)) * 86400 * 1000
       since_query <- paste0("&since=", since_integer)
     }
 
     until_query <- ""
     if (!is.null(until)) {
-      # API parameters until awaits number of milliseconds since 1970-01-01
+      # API parameter until awaits number of milliseconds since 1970-01-01
       until_integer <- ((as.integer(as.Date(until)) + 1) * 86400 * 1000) - 1
       until_query <- paste0("&until=", until_integer)
     }

--- a/R/get_raw_lichess.R
+++ b/R/get_raw_lichess.R
@@ -30,12 +30,14 @@ get_raw_lichess <- function(player_names, since = NULL, until = NULL) {
 
     since_query <- ""
     if (!is.null(since)) {
+      # API parameters since awaits number of milliseconds since 1970-01-01
       since_integer <- as.integer(as.Date(since)) * 86400 * 1000
       since_query <- paste0("&since=", since_integer)
     }
 
     until_query <- ""
     if (!is.null(until)) {
+      # API parameters until awaits number of milliseconds since 1970-01-01
       until_integer <- ((as.integer(as.Date(until)) + 1) * 86400 * 1000) - 1
       until_query <- paste0("&until=", until_integer)
     }

--- a/R/get_raw_lichess.R
+++ b/R/get_raw_lichess.R
@@ -101,10 +101,12 @@ get_raw_lichess <- function(player_names, since = NULL, until = NULL) {
       purrr::map_df(create_games_df)
     # apply the user's names
     output$Username <- each_player
-    # filter out games where the variant is 'From Position'
-    output <- output %>% dplyr::filter(.data$Variant != "From Position")
+    if (nrow(output)) {
+      # filter out games where the variant is 'From Position'
+      output <- output %>% dplyr::filter(.data$Variant != "From Position")
+      final_output <- dplyr::bind_rows(final_output, output)
+    }
 
-    final_output <- dplyr::bind_rows(final_output, output)
   }
   return(final_output)
 }

--- a/R/get_raw_lichess.R
+++ b/R/get_raw_lichess.R
@@ -4,6 +4,11 @@
 #' Lichess data as a data frame
 #'
 #' @param player_names A vector of a valid username or usernames from Lichess
+#' @param since Games played since this date. An object of class `Date` or a
+#'   string of the form `"yyyy-mm-dd"`. If `NULL`, defaults to account creation
+#'   date.
+#' @param until Games played until this date. An object of class `Date` or a
+#'   string of the form `"yyyy-mm-dd"`. If `NULL`, defaults to now.
 #'
 #' @return a dataframe of lichess data
 #'
@@ -15,16 +20,32 @@
 #' @examples
 #' \dontrun{
 #' georges_data <- get_raw_lichess(player_names = "Georges")
+#' the_knife_data <- get_raw_lichess("the_knife", since = "2023-08-13", until = "2023-08-14")
 #' }
-get_raw_lichess <- function(player_names) {
+get_raw_lichess <- function(player_names, since = NULL, until = NULL) {
 
   get_file <- function(player_name) {
 
     # cat("Extracting ", player_name, " games. Please wait\n")
 
+    since_query <- ""
+    if (!is.null(since)) {
+      since_integer <- as.integer(as.Date(since)) * 86400 * 1000
+      since_query <- paste0("&since=", since_integer)
+    }
+
+    until_query <- ""
+    if (!is.null(until)) {
+      until_integer <- ((as.integer(as.Date(until)) + 1) * 86400 * 1000) - 1
+      until_query <- paste0("&until=", until_integer)
+    }
+
     # download the tmp file
     tmp <- tempfile()
-    curl::curl_download(paste0("https://lichess.org/api/games/user/", player_name, "?evals=true&clocks=true&opening=true"), tmp)
+    curl::curl_download(
+      paste0("https://lichess.org/api/games/user/", player_name, "?evals=true&clocks=true&opening=true", since_query, until_query),
+      tmp
+    )
     # read in the file
     read_in_file <- readLines(tmp)
     # cleaning steps of the file

--- a/man/get_raw_lichess.Rd
+++ b/man/get_raw_lichess.Rd
@@ -4,10 +4,17 @@
 \alias{get_raw_lichess}
 \title{Get Raw Lichess Game Data}
 \usage{
-get_raw_lichess(player_names)
+get_raw_lichess(player_names, since = NULL, until = NULL)
 }
 \arguments{
 \item{player_names}{A vector of a valid username or usernames from Lichess}
+
+\item{since}{Games played since this date. An object of class `Date` or a
+string of the form `"yyyy-mm-dd"`. If `NULL`, defaults to account creation
+date.}
+
+\item{until}{Games played until this date. An object of class `Date` or a
+string of the form `"yyyy-mm-dd"`. If `NULL`, defaults to now.}
 }
 \value{
 a dataframe of lichess data
@@ -19,5 +26,6 @@ Lichess data as a data frame
 \examples{
 \dontrun{
 georges_data <- get_raw_lichess(player_names = "Georges")
+the_knife_data <- get_raw_lichess("the_knife", since = "2023-08-13", until = "2023-08-14")
 }
 }

--- a/tests/testthat/test-chessR.R
+++ b/tests/testthat/test-chessR.R
@@ -22,6 +22,15 @@ test_that("get_raw_lichess() works", {
   lichess_game_data <- get_raw_lichess("JaseZiv")
   expect_type(lichess_game_data, "list")
   expect_true(nrow(lichess_game_data) != 0)
+  # tests for date parameters
+  lichess_game_data <- get_raw_lichess("JaseZiv", since = "2020-11-01", until = "2020-11-03")
+  expect_type(lichess_game_data, "list")
+  expect_true(nrow(lichess_game_data) == 13)
+  expect_true(all(lichess_game_data$Date %in% paste0("2020.11.0", 1:3)))
+  # no games for the chosen dates
+  lichess_game_data <- get_raw_lichess("JaseZiv", until = "2019-01-01")
+  expect_type(lichess_game_data, "list")
+  expect_true(nrow(lichess_game_data) == 0)
 })
 
 


### PR DESCRIPTION
A proposition for adding a filter by date for the `get_raw_lichess` function.