### PR TITLE
prevent scientific notation in query

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: chessR
 Type: Package
 Title: Functions to Extract, Clean and Analyse Online Chess Game Data
-Version: 1.5.3
+Version: 1.5.4
 Authors@R: c(person("Jason Zivkovic", email = "jase.ziv83@gmail.com",
                   role = c("aut", "cre")),
              person("Jonathan", "Carroll", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 Bugfix: prevent scientific notation in time queries for `get_raw_lichess()`
 (@py-b #18)
 
+***
+
 # chessR 1.5.3
 
 Feature: `get_raw_lichess()` can now be filtered by date with the parameters

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# chessR 1.5.4
+
+Bugfix: prevent scientific notation in time queries for `get_raw_lichess()`
+(@py-b #18)
+
 # chessR 1.5.3
 
 Feature: `get_raw_lichess()` can now be filtered by date with the parameters

--- a/R/get_raw_lichess.R
+++ b/R/get_raw_lichess.R
@@ -28,6 +28,9 @@ get_raw_lichess <- function(player_names, since = NULL, until = NULL) {
 
     # cat("Extracting ", player_name, " games. Please wait\n")
 
+    old_scipen = getOption("scipen")
+    options(scipen = 1000000)
+
     since_query <- ""
     if (!is.null(since)) {
       # API parameter since awaits number of milliseconds since 1970-01-01
@@ -41,6 +44,8 @@ get_raw_lichess <- function(player_names, since = NULL, until = NULL) {
       until_integer <- ((as.integer(as.Date(until)) + 1) * 86400 * 1000) - 1
       until_query <- paste0("&until=", until_integer)
     }
+
+    options(scipen = old_scipen)
 
     # download the tmp file
     tmp <- tempfile()


### PR DESCRIPTION
a little fix to prevent things like `since=1.7172e+12` in time queries